### PR TITLE
Added new simpler convertor for OO

### DIFF
--- a/webodt/conf.py
+++ b/webodt/conf.py
@@ -14,3 +14,4 @@ WEBODT_ODF_TEMPLATE_PREPROCESSORS = getattr(settings, 'WEBODT_ODF_TEMPLATE_PREPR
     'webodt.preprocessors.xmlfor_preprocessor',
     'webodt.preprocessors.unescape_templatetags_preprocessor',
 ])
+WEBODT_OOBIN_COMMAND = getattr(settings, 'WEBODT_OOBIN_COMMAND', '')

--- a/webodt/converters/openofficebin.py
+++ b/webodt/converters/openofficebin.py
@@ -1,0 +1,11 @@
+class OpenOfficeBinODFConverter(ODFConverter):
+
+
+    def convert(self, document, format=None, output_filename=None, delete_on_close=True):
+        output_filename, format = self._guess_format_and_filename(output_filename, format)
+	where_is_file = os.path.dirname(document.name)
+	basename = os.path.basename(document.name)
+ 	os.system("cd "+where_is_file+ " && "+str(WEBODT_OOBIN_COMMAND)+" --headless --invisible --convert-to pdf "+str(document.name))
+	converted_filename = re.sub(r"\.odt",".pdf", str(document.name))
+	fd = Document(converted_filename, mode='r', delete_on_close=False)
+        return fd


### PR DESCRIPTION
Hi, 
I enhanced your library with a lot simpler convertor using OO. Why did i do it since we have OO converter already?
1. It is the ONLY way to make your library convert documents on Mac OS X
    - abiword for Intel is not to be found (and compiling it on Macports or elsewhere is a big PAIN)
    - gdrive has issues (table borders) --> http://goo.gl/B8B5B
    - PyUNO is broken on Mac OS (and elsewhere as I hear - http://goo.gl/3MzNm)
2. It is much more see-through code than using pyuno magic. I used "Abiword converter template"

Tested and working Mac OS 10.7 Server; Ubuntu 12.10

I order to make this all work you need to set in settings.py:
WEBODT_CONVERTER = 'webodt.converters.openofficebin.OpenOfficeBinODFConverter'
WEBODT_OOBIN_COMMAND = '/Applications/LibreOffice.app/Contents/MacOS/soffice'

Also on Mac OS it is needed to set a temp folder OUTSIDE /var e.g.
WEBODT_TMP_DIR = "/Users/kosta/git/my_project/resources/tmp_webodt"
(OO has problems with rights)
